### PR TITLE
Remove apt-maven-plugin settings

### DIFF
--- a/Ch19/querydsl/pom.xml
+++ b/Ch19/querydsl/pom.xml
@@ -28,22 +28,6 @@
                     </includes>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>com.mysema.maven</groupId>
-                <artifactId>apt-maven-plugin</artifactId>
-                <version>1.1.3</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>process</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>target/generated-sources/java</outputDirectory>
-                            <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -84,6 +68,7 @@
             <artifactId>querydsl-apt</artifactId>
             <version>5.0.0</version>
             <scope>provided</scope>
+            <classifier>jpa</classifier>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>


### PR DESCRIPTION
Hello 

In the **querydsl** example project, it appears that the `apt-maven-plugin` configuration isn’t necessary. 

By explicitly setting the classifier of `querydsl-apt` to `jpa`, the `maven-compiler-plugin` seems to handle the annotation processor well, even without the `apt-maven-plugin` configuration.

thank you have a good day.  👍

* https://github.com/querydsl/querydsl/issues/3201
